### PR TITLE
Feature terachem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,15 @@ jobs:
       - full_image_name:
           docker_repo: << parameters.docker_repo >>
       - run:
+          name: Docker login
+          command: echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
+      - run:
           name: Build image
           command: |
             docker build -t ${FULL_IMAGE_NAME} -f docker/<< parameters.dockerfile_name >> .
       - run:
           name: Push image to Martinez Group Docker Hub
           command: |
-            echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
             docker image push ${FULL_IMAGE_NAME}
             if [ ! -z $CIRCLE_TAG ]
             then
@@ -225,7 +227,7 @@ jobs:
     docker:
       - image: cimg/base:2020.01
         environment:
-          DOCKER_COMPOSE_FILENAME: docker-compose.worker.yaml
+          DOCKER_COMPOSE_FILENAME: docker-compose.xstream.<< parameters.stage >>.yaml
           SERVER_FILEPATH: << pipeline.parameters.server_stacks_directory >>/<< parameters.stage >>/tcc
           XSTREAM_LOGIN_HOST: xstream-login.stanford.edu
     steps:
@@ -244,7 +246,6 @@ jobs:
       - run:
           name: Fill docker-compose template with context
           command: |
-            source docker/context.<< parameters.stage >>
             eval "echo \"$(cat $(pwd)/docker/${DOCKER_COMPOSE_FILENAME})\"" > ${DOCKER_COMPOSE_FILENAME}
       - run:
           name: Login to XStream with kinit
@@ -259,8 +260,14 @@ jobs:
           name: Push docker-compose files to server
           command: scp -o ProxyCommand="ssh -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes ${STANFORD_UN}@xstream-login.stanford.edu nc xs7-0001 22" -o StrictHostKeyChecking=no ${DOCKER_COMPOSE_FILENAME} ${STANFORD_UN}@xs7-0001:${SERVER_FILEPATH}/${DOCKER_COMPOSE_FILENAME}
       - run:
+          name: Login server to Martinez Group Docker Repo
+          command: |
+            ESCAPED_DOCKERHUB_PASSWORD=`printf "%q" ${DOCKERHUB_PASSWORD}` #  pragma: allowlist secret
+            ssh -o ProxyCommand="ssh -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes ${STANFORD_UN}@xstream-login.stanford.edu nc xs7-0001 22" -o StrictHostKeyChecking=no ${STANFORD_UN}@xs7-0001 ESCAPED_DOCKERHUB_PASSWORD=${ESCAPED_DOCKERHUB_PASSWORD} DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME} "echo ${ESCAPED_DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USERNAME} --password-stdin" #  pragma: allowlist secret
+      - run:
           name: Deploy docker stack on server
-          command: ssh -o ProxyCommand="ssh -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes ${STANFORD_UN}@xstream-login.stanford.edu nc xs7-0001 22" -o StrictHostKeyChecking=no ${STANFORD_UN}@xs7-0001 "docker stack deploy -c ${SERVER_FILEPATH}/${DOCKER_COMPOSE_FILENAME} << parameters.stage >>-tcc-worker"
+          command: |
+            ssh -o ProxyCommand="ssh -o GSSAPIAuthentication=yes -o GSSAPIDelegateCredentials=yes ${STANFORD_UN}@xstream-login.stanford.edu nc xs7-0001 22" -o StrictHostKeyChecking=no ${STANFORD_UN}@xs7-0001 "docker stack deploy --with-registry-auth -c ${SERVER_FILEPATH}/${DOCKER_COMPOSE_FILENAME} << parameters.stage >>-tcc-worker"
 
 workflows:
   main:
@@ -274,110 +281,97 @@ workflows:
       - isort
       - mypy
 
-      - dev_deploy_web:
+      # Build Web
+      - build_web_approval:
           type: approval
-          requires:
-            - test_code
           filters:
             tags:
-              only: /.*/
+              only: /.*/ # required since prod_web_deploy requires this step and has tag filters
       - build:
-          name: dev_web_build
+          name: web_build
           requires:
-            - dev_deploy_web
+            - test_code
+            - build_web_approval
           docker_repo: terachem-cloud
           dockerfile_name: server.dockerfile
           filters:
             tags:
-              only: /.*/
-      - deploy_web:
-          name: dev_web_deploy
-          context: dev-mtzlab
-          ssh-fingerprint: 35:2d:cc:27:f9:79:bf:6c:c1:7f:24:1d:f4:07:8c:d3
-          requires:
-            - dev_web_build
-          stage: dev
+              only: /.*/ # required since prod_web_deploy requires this step and has tag filters
+
+      # Build Workers
+      - build_workers_approval:
+          type: approval
           filters:
             tags:
-              only: /.*/
-
-      - dev_deploy_workers:
-          type: approval
+              only: /.*/ # required since prod_workers_deploy requires this step and has tag filters
+      - build:
+          name: worker_build
           requires:
             - test_code
-          filters:
-            tags:
-              only: /.*/
-      - build:
-          name: dev_worker_build
-          requires:
-            - dev_deploy_workers
+            - build_workers_approval
           docker_repo: terachem-cloud-worker
           dockerfile_name: celeryworker.dockerfile
           filters:
             tags:
-              only: /.*/
+              only: /.*/ # required since prod_workers_deploy requires this step and has tag filters
+
+      # Deploy dev
+      - dev_deploy_web_approval:
+          type: approval
+      - deploy_web:
+          name: dev_web_deploy
+          context: dev-context
+          ssh-fingerprint: 35:2d:cc:27:f9:79:bf:6c:c1:7f:24:1d:f4:07:8c:d3
+          requires:
+            - dev_deploy_web_approval
+            - web_build
+          stage: dev
+
+      - dev_deploy_workers_approval:
+          type: approval
       - deploy_workers:
           name: dev_workers_deploy
           requires:
-            - dev_worker_build
+            - dev_deploy_workers_approval
+            - worker_build
           stage: dev
-          filters:
-            tags:
-              only: /.*/
 
-      - prod_deploy_web:
+      - prod_deploy_web_approval:
           type: approval
           filters: # Only run on x.x.x tagged branches
             tags:
               only: /\d*\.\d*\.\d*/
             branches:
               ignore: /.*/
-          requires:
-            - test_code
-      - build:
-          name: prod_web_build
-          requires:
-            - prod_deploy_web
-          filters:
-            tags:
-              only: /\d*\.\d*\.\d*/
-          docker_repo: terachem-cloud
-          dockerfile_name: server.dockerfile
       - deploy_web:
           name: prod_web_deploy
-          context: prod-mtzlab
+          context: prod-context
           ssh-fingerprint: fa:2a:8d:76:3f:41:e5:de:65:88:67:2a:9a:8a:11:ca
           filters:
             tags:
               only: /\d*\.\d*\.\d*/
+            branches:
+              ignore: /.*/
           requires:
-            - prod_web_build
+            - prod_deploy_web_approval
+            - web_build
           stage: prod
 
-      - prod_deploy_worker:
+      - prod_deploy_worker_approval:
           type: approval
           filters: # Only run on tagged branches
             tags:
               only: /\d*\.\d*\.\d*/
             branches:
               ignore: /.*/
-          requires:
-            - test_code
-      - build:
-          name: prod_worker_build
-          filters:
-            tags:
-              only: /\d*\.\d*\.\d*/
-          requires:
-            - prod_deploy_worker
-          docker_repo: terachem-cloud-worker
-          dockerfile_name: celeryworker.dockerfile
       - deploy_workers:
           name: prod_workers_deploy
           filters:
             tags:
               only: /\d*\.\d*\.\d*/
+            branches:
+              ignore: /.*/
           requires:
-            - prod_worker_build
+            - prod_deploy_worker_approval
+            - worker_build
           stage: prod

--- a/Pipfile
+++ b/Pipfile
@@ -17,7 +17,6 @@ pytest-timeout = "*"
 
 [packages]
 fastapi = "*"
-qcengine = "*"
 celery = {extras = ["redis"], version = "*"}
 python-jose = {extras = ["cryptography"], version = "*"}
 python-multipart = "*"
@@ -30,6 +29,11 @@ uvloop = "*"
 httptools = "*"
 typing-extensions = "*"
 aiofiles = "*"
+qcengine = {ref = "feature-terachem-pbs-harness", git = "https://github.com/mtzgroup/QCEngine.git"}
+amqp = "==5.0.2"
+tcpb = {ref = "develop", git = "https://github.com/mtzgroup/tcpb-client.git"}
+google = "==1.9.3"
+protobuf = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d6dee48938878a47850aafdbfda31b202bc1b20f8f4eaf618791c1c9953979b1"
+            "sha256": "c9e215e85871adc6975b5c9f812d1ac91b64cb711e00ebe9127477f83d7a6ff2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -29,8 +29,16 @@
                 "sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a",
                 "sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==5.0.2"
+        },
+        "beautifulsoup4": {
+            "hashes": [
+                "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35",
+                "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25",
+                "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"
+            ],
+            "version": "==4.9.3"
         },
         "billiard": {
             "hashes": [
@@ -59,44 +67,45 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e",
-                "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d",
-                "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a",
-                "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec",
-                "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362",
-                "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668",
-                "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c",
-                "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b",
-                "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06",
-                "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698",
-                "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2",
-                "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c",
-                "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7",
-                "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009",
-                "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03",
-                "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b",
-                "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909",
-                "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53",
-                "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35",
-                "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26",
-                "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b",
-                "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01",
-                "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb",
-                "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293",
-                "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd",
-                "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d",
-                "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3",
-                "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d",
-                "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e",
-                "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca",
-                "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d",
-                "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775",
-                "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375",
-                "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b",
-                "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b",
-                "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"
+                "sha256:005a36f41773e148deac64b08f233873a4d0c18b053d37da83f6af4d9087b813",
+                "sha256:0857f0ae312d855239a55c81ef453ee8fd24136eaba8e87a2eceba644c0d4c06",
+                "sha256:1071534bbbf8cbb31b498d5d9db0f274f2f7a865adca4ae429e147ba40f73dea",
+                "sha256:158d0d15119b4b7ff6b926536763dc0714313aa59e320ddf787502c70c4d4bee",
+                "sha256:1f436816fc868b098b0d63b8920de7d208c90a67212546d02f84fe78a9c26396",
+                "sha256:2894f2df484ff56d717bead0a5c2abb6b9d2bf26d6960c4604d5c48bbc30ee73",
+                "sha256:29314480e958fd8aab22e4a58b355b629c59bf5f2ac2492b61e3dc06d8c7a315",
+                "sha256:34eff4b97f3d982fb93e2831e6750127d1355a923ebaeeb565407b3d2f8d41a1",
+                "sha256:35f27e6eb43380fa080dccf676dece30bef72e4a67617ffda586641cd4508d49",
+                "sha256:3d3dd4c9e559eb172ecf00a2a7517e97d1e96de2a5e610bd9b68cea3925b4892",
+                "sha256:43e0b9d9e2c9e5d152946b9c5fe062c151614b262fda2e7b201204de0b99e482",
+                "sha256:48e1c69bbacfc3d932221851b39d49e81567a4d4aac3b21258d9c24578280058",
+                "sha256:51182f8927c5af975fece87b1b369f722c570fe169f9880764b1ee3bca8347b5",
+                "sha256:58e3f59d583d413809d60779492342801d6e82fefb89c86a38e040c16883be53",
+                "sha256:5de7970188bb46b7bf9858eb6890aad302577a5f6f75091fd7cdd3ef13ef3045",
+                "sha256:65fa59693c62cf06e45ddbb822165394a288edce9e276647f0046e1ec26920f3",
+                "sha256:69e395c24fc60aad6bb4fa7e583698ea6cc684648e1ffb7fe85e3c1ca131a7d5",
+                "sha256:6c97d7350133666fbb5cf4abdc1178c812cb205dc6f41d174a7b0f18fb93337e",
+                "sha256:6e4714cc64f474e4d6e37cfff31a814b509a35cb17de4fb1999907575684479c",
+                "sha256:72d8d3ef52c208ee1c7b2e341f7d71c6fd3157138abf1a95166e6165dd5d4369",
+                "sha256:8ae6299f6c68de06f136f1f9e69458eae58f1dacf10af5c17353eae03aa0d827",
+                "sha256:8b198cec6c72df5289c05b05b8b0969819783f9418e0409865dac47288d2a053",
+                "sha256:99cd03ae7988a93dd00bcd9d0b75e1f6c426063d6f03d2f90b89e29b25b82dfa",
+                "sha256:9cf8022fb8d07a97c178b02327b284521c7708d7c71a9c9c355c178ac4bbd3d4",
+                "sha256:9de2e279153a443c656f2defd67769e6d1e4163952b3c622dcea5b08a6405322",
+                "sha256:9e93e79c2551ff263400e1e4be085a1210e12073a31c2011dbbda14bda0c6132",
+                "sha256:9ff227395193126d82e60319a673a037d5de84633f11279e336f9c0f189ecc62",
+                "sha256:a465da611f6fa124963b91bf432d960a555563efe4ed1cc403ba5077b15370aa",
+                "sha256:ad17025d226ee5beec591b52800c11680fca3df50b8b29fe51d882576e039ee0",
+                "sha256:afb29c1ba2e5a3736f1c301d9d0abe3ec8b86957d04ddfa9d7a6a42b9367e396",
+                "sha256:b85eb46a81787c50650f2392b9b4ef23e1f126313b9e0e9013b35c15e4288e2e",
+                "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991",
+                "sha256:cbde590d4faaa07c72bf979734738f328d239913ba3e043b1e98fe9a39f8b2b6",
+                "sha256:cd2868886d547469123fadc46eac7ea5253ea7fcb139f12e1dfc2bbd406427d1",
+                "sha256:d42b11d692e11b6634f7613ad8df5d6d5f8875f5d48939520d351007b3c13406",
+                "sha256:f2d45f97ab6bb54753eab54fffe75aaf3de4ff2341c9daee1987ee1837636f1d",
+                "sha256:fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
             ],
-            "version": "==1.14.4"
+            "version": "==1.14.5"
         },
         "click": {
             "hashes": [
@@ -128,29 +137,27 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0003a52a123602e1acee177dc90dd201f9bb1e73f24a070db7d36c588e8f5c7d",
-                "sha256:0e85aaae861d0485eb5a79d33226dd6248d2a9f133b81532c8f5aae37de10ff7",
-                "sha256:594a1db4511bc4d960571536abe21b4e5c3003e8750ab8365fafce71c5d86901",
-                "sha256:69e836c9e5ff4373ce6d3ab311c1a2eed274793083858d3cd4c7d12ce20d5f9c",
-                "sha256:788a3c9942df5e4371c199d10383f44a105d67d401fb4304178020142f020244",
-                "sha256:7e177e4bea2de937a584b13645cab32f25e3d96fc0bc4a4cf99c27dc77682be6",
-                "sha256:83d9d2dfec70364a74f4e7c70ad04d3ca2e6a08b703606993407bf46b97868c5",
-                "sha256:84ef7a0c10c24a7773163f917f1cb6b4444597efd505a8aed0a22e8c4780f27e",
-                "sha256:9e21301f7a1e7c03dbea73e8602905a4ebba641547a462b26dd03451e5769e7c",
-                "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0",
-                "sha256:a69bd3c68b98298f490e84519b954335154917eaab52cf582fa2c5c7efc6e812",
-                "sha256:b4890d5fb9b7a23e3bf8abf5a8a7da8e228f1e97dc96b30b95685df840b6914a",
-                "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030",
-                "sha256:dc42f645f8f3a489c3dd416730a514e7a91a59510ddaadc09d04224c098d3302"
+                "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b",
+                "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336",
+                "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87",
+                "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7",
+                "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799",
+                "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b",
+                "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df",
+                "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0",
+                "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3",
+                "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724",
+                "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2",
+                "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"
             ],
-            "version": "==3.3.1"
+            "version": "==3.4.6"
         },
         "ecdsa": {
             "hashes": [
                 "sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e",
                 "sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.14.1"
         },
         "fastapi": {
@@ -160,6 +167,15 @@
             ],
             "index": "pypi",
             "version": "==0.63.0"
+        },
+        "google": {
+            "hashes": [
+                "sha256:1b36b0fd5bbc1d59dc8bf082141ef7dbac1e6441feef1a667fe25a6b5203d70c",
+                "sha256:31cc5a7f39b9d864c3b17367f803e4e02853ac37bf2071cf5443506914fef602",
+                "sha256:7c312681eafff0156a23b430eff320734da2430ac76973ffff1e396c096b8ebe"
+            ],
+            "index": "pypi",
+            "version": "==1.9.3"
         },
         "gunicorn": {
             "hashes": [
@@ -179,11 +195,11 @@
         },
         "httpcore": {
             "hashes": [
-                "sha256:420700af11db658c782f7e8fda34f9dcd95e3ee93944dd97d78cb70247e0cd06",
-                "sha256:dd1d762d4f7c2702149d06be2597c35fb154c5eff9789a8c5823fbcf4d2978d6"
+                "sha256:37ae835fb370049b2030c3290e12ed298bf1473c41bb72ca4aa78681eba9b7c9",
+                "sha256:93e822cd16c32016b414b789aeff4e855d0ccbfc51df563ee34d4dbadbb3bcdc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==0.12.2"
+            "version": "==0.12.3"
         },
         "httptools": {
             "hashes": [
@@ -220,11 +236,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
-                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
+                "sha256:2a851a30a1fd847cedd68c7c6bfb90e765db6265852f574e9d88bb40f96924ab",
+                "sha256:31c5c29f17d064cc71bf6a005a8b25b3332787ab2e7362d5d258800ac825f471"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==3.3.0"
+            "markers": "python_version < '3.8'",
+            "version": "==3.5.0"
         },
         "kombu": {
             "hashes": [
@@ -236,51 +252,41 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94",
-                "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080",
-                "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e",
-                "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c",
-                "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76",
-                "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371",
-                "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c",
-                "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2",
-                "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a",
-                "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb",
-                "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140",
-                "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28",
-                "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f",
-                "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d",
-                "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff",
-                "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8",
-                "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa",
-                "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea",
-                "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc",
-                "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73",
-                "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d",
-                "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d",
-                "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4",
-                "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c",
-                "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e",
-                "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea",
-                "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd",
-                "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f",
-                "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff",
-                "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e",
-                "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7",
-                "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa",
-                "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827",
-                "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"
+                "sha256:032be656d89bbf786d743fee11d01ef318b0781281241997558fa7950028dd29",
+                "sha256:104f5e90b143dbf298361a99ac1af4cf59131218a045ebf4ee5990b83cff5fab",
+                "sha256:125a0e10ddd99a874fd357bfa1b636cd58deb78ba4a30b5ddb09f645c3512e04",
+                "sha256:12e4ba5c6420917571f1a5becc9338abbde71dd811ce40b37ba62dec7b39af6d",
+                "sha256:13adf545732bb23a796914fe5f891a12bd74cf3d2986eed7b7eba2941eea1590",
+                "sha256:2d7e27442599104ee08f4faed56bb87c55f8b10a5494ac2ead5c98a4b289e61f",
+                "sha256:3bc63486a870294683980d76ec1e3efc786295ae00128f9ea38e2c6e74d5a60a",
+                "sha256:3d3087e24e354c18fb35c454026af3ed8997cfd4997765266897c68d724e4845",
+                "sha256:4ed8e96dc146e12c1c5cdd6fb9fd0757f2ba66048bf94c5126b7efebd12d0090",
+                "sha256:60759ab15c94dd0e1ed88241fd4fa3312db4e91d2c8f5a2d4cf3863fad83d65b",
+                "sha256:65410c7f4398a0047eea5cca9b74009ea61178efd78d1be9847fac1d6716ec1e",
+                "sha256:66b467adfcf628f66ea4ac6430ded0614f5cc06ba530d09571ea404789064adc",
+                "sha256:7199109fa46277be503393be9250b983f325880766f847885607d9b13848f257",
+                "sha256:72251e43ac426ff98ea802a931922c79b8d7596480300eb9f1b1e45e0543571e",
+                "sha256:89e5336f2bec0c726ac7e7cdae181b325a9c0ee24e604704ed830d241c5e47ff",
+                "sha256:89f937b13b8dd17b0099c7c2e22066883c86ca1575a975f754babc8fbf8d69a9",
+                "sha256:9c94cab5054bad82a70b2e77741271790304651d584e2cdfe2041488e753863b",
+                "sha256:9eb551d122fadca7774b97db8a112b77231dcccda8e91a5bc99e79890797175e",
+                "sha256:a1d7995d1023335e67fb070b2fae6f5968f5be3802b15ad6d79d81ecaa014fe0",
+                "sha256:ae61f02b84a0211abb56462a3b6cd1e7ec39d466d3160eb4e1da8bf6717cdbeb",
+                "sha256:b9410c0b6fed4a22554f072a86c361e417f0258838957b78bd063bde2c7f841f",
+                "sha256:c26287dfc888cf1e65181f39ea75e11f42ffc4f4529e5bd19add57ad458996e2",
+                "sha256:c91ec9569facd4757ade0888371eced2ecf49e7982ce5634cc2cf4e7331a4b14",
+                "sha256:ecb5b74c702358cdc21268ff4c37f7466357871f53a30e6f84c686952bef16a9"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.19.5"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.20.1"
         },
         "packaging": {
             "hashes": [
-                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
-                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.8"
+            "version": "==20.9"
         },
         "pint": {
             "hashes": [
@@ -292,11 +298,37 @@
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:ac329c69bd8564cb491940511957312c7b8959bb5b3cf3582b406068a51d5bb7",
-                "sha256:b8b3d0bde65da350290c46a8f54f336b3cbf5464a4ac11239668d986852e79d5"
+                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
+                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.0.10"
+            "version": "==3.0.16"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:01fbd6e4941322faf7c6796f3878f4bf4b47a096793c257094087c15a1911cff",
+                "sha256:128913a812baac25cc103e266f3c4d181a8068ab92e2963a07d4af808d759a67",
+                "sha256:1e9728664dd815c5d8897353f2f53412b34de4526d271342d4a36f065c0ff854",
+                "sha256:20d42cdab69072cb123480d1cd7483ba0268ab31539f889e2464a10456808500",
+                "sha256:2311afdcf3f227d157f9fff05333184f6498de6893f0d0774d8ff5e1aa6844b3",
+                "sha256:3df7eb48fbe9cc80aaca24fce00df9d26e82787e1ed2b2ad764fe007df7cd135",
+                "sha256:436686d08278239c574c8dbef8846134a3ad1357c15e20d3f3b7c2d4e047d146",
+                "sha256:476999c3ac127d43e1c7ae108b3a060516e972bd41da6512b83d2bced8806cdc",
+                "sha256:57d723a86209f0747def4196af197728842d8d0fa3d2d4166f44bfc4661c3d17",
+                "sha256:5e812acefa4a0beba1cc2a120b3394709d43ebd19371f55f9a6e817da05b2cae",
+                "sha256:64efb367cea64ba183f7c81ad1de1e52b5aba68dbec67927eb5a9253a3bc87f2",
+                "sha256:659666a9e5aa141b5009b2e5a28c9fc6a0cc65ff66f8e8552104de54168badf1",
+                "sha256:7a58c72722cbf12451b2f52c60eaf4827ac46afc64c6807b3d794d80c314763d",
+                "sha256:aed9db65b3a5df46911014a5347016ee4c3b71606a49419bdd8d3fe8a6728bab",
+                "sha256:b3b821907dffe0c53a27f444cbefe7fd1c830230d5c1662717565e0f0e11aa33",
+                "sha256:c8cd5aea2f088eb031efe78e847ebf3b24caa3815ec088fa6e11474a1a1b8cb1",
+                "sha256:c9c4e15d4ca60c3283b62521a52a173f56aeec8771c18e15bd375af672aec3c7",
+                "sha256:d55a518ee1eeb09da5e94bdbf592b156246a479c17c06290732ddf6daafc51de",
+                "sha256:dff4531a6e24b5642fe08518dc90f42a2fdc310c49bde98c78cdcc3790b9b505",
+                "sha256:f395501ce7d94e96cd98afc2daf845f31c49bdfc40fb258abcd8971461eb80a1"
+            ],
+            "index": "pypi",
+            "version": "==3.15.2"
         },
         "psutil": {
             "hashes": [
@@ -397,7 +429,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dotenv": {
@@ -428,44 +460,49 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4",
-                "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2020.5"
+            "version": "==2021.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
-                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
             ],
-            "version": "==5.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "qcelemental": {
             "hashes": [
-                "sha256:4110c285ec40bfbf67041c3f0651b7af617adc14fe0565807ae2504383ac5d77",
-                "sha256:5b7f3017aaf4942720d1a63bacc306dc974124871db65f910a2b01d2f8cf4840"
+                "sha256:3f666fdba8ab9d400eddacf3772399be956c95f53b1bc51fab00dadbc791b4d7",
+                "sha256:f6cca8c7c657714e474a564341670780c998e778cc5fc3ec8ce774754b2ba227"
             ],
             "index": "pypi",
-            "version": "==0.17.0"
+            "version": "==0.18.0"
         },
         "qcengine": {
-            "hashes": [
-                "sha256:19a2ca5a341514f8f6c491e7570ecd4e98cf31290bd34d47a475722100cc971d",
-                "sha256:5878e02a8ffcf6582390ebe3f00aa338317f28ba4bdb204098f9dcc30f69924d"
-            ],
-            "index": "pypi",
-            "version": "==0.17.0"
+            "git": "https://github.com/mtzgroup/QCEngine.git",
+            "ref": "ae396427e975f3f9ec328a6a6a1ce8f96f427f50"
         },
         "redis": {
             "hashes": [
@@ -486,18 +523,18 @@
         },
         "rsa": {
             "hashes": [
-                "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa",
-                "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"
+                "sha256:74ba16e7ef58920b80b5c54c1c1066d391a2c1e812c466773f74c634eb12253b",
+                "sha256:9d74d1ff850745c9802cd6b53382bfeec7f6dbe4e26ee2759241ed1e7b0ecf5d"
             ],
             "markers": "python_version >= '3.5' and python_version < '4'",
-            "version": "==4.6"
+            "version": "==4.7.1"
         },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "sniffio": {
@@ -508,6 +545,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.2.0"
         },
+        "soupsieve": {
+            "hashes": [
+                "sha256:407fa1e8eb3458d1b5614df51d9651a1180ea5fedf07feb46e45d7e25e6d6cdd",
+                "sha256:d3a5ea5b350423f47d07639f74475afedad48cf41c0ad7a82ca13a3928af34f6"
+            ],
+            "markers": "python_version >= '3.0'",
+            "version": "==2.2"
+        },
         "starlette": {
             "hashes": [
                 "sha256:bd2ffe5e37fb75d014728511f8e68ebf2c80b0fa3d04ca1479f4dc752ae31ac9",
@@ -515,6 +560,10 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==0.13.6"
+        },
+        "tcpb": {
+            "git": "https://github.com/mtzgroup/tcpb-client.git",
+            "ref": "2c434c45774e157a7ce9ff945c1366de10ef13ea"
         },
         "typing-extensions": {
             "hashes": [
@@ -527,26 +576,27 @@
         },
         "uvicorn": {
             "hashes": [
-                "sha256:1079c50a06f6338095b4f203e7861dbff318dde5f22f3a324fc6e94c7654164c",
-                "sha256:ef1e0bb5f7941c6fe324e06443ddac0331e1632a776175f87891c7bd02694355"
+                "sha256:3292251b3c7978e8e4a7868f4baf7f7f7bb7e40c759ecc125c37e99cdea34202",
+                "sha256:7587f7b08bd1efd2b9bad809a3d333e972f1d11af8a5e52a9371ee3a5de71524"
             ],
             "index": "pypi",
-            "version": "==0.13.3"
+            "version": "==0.13.4"
         },
         "uvloop": {
             "hashes": [
-                "sha256:08b109f0213af392150e2fe6f81d33261bb5ce968a288eb698aad4f46eb711bd",
-                "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e",
-                "sha256:4315d2ec3ca393dd5bc0b0089d23101276778c304d42faff5dc4579cb6caef09",
-                "sha256:4544dcf77d74f3a84f03dd6278174575c44c67d7165d4c42c71db3fdc3860726",
-                "sha256:afd5513c0ae414ec71d24f6f123614a80f3d27ca655a4fcf6cabe50994cc1891",
-                "sha256:b4f591aa4b3fa7f32fb51e2ee9fea1b495eb75b0b3c8d0ca52514ad675ae63f7",
-                "sha256:bcac356d62edd330080aed082e78d4b580ff260a677508718f88016333e2c9c5",
-                "sha256:e7514d7a48c063226b7d06617cbb12a14278d4323a065a8d46a7962686ce2e95",
-                "sha256:f07909cd9fc08c52d294b1570bba92186181ca01fe3dc9ffba68955273dd7362"
+                "sha256:114543c84e95df1b4ff546e6e3a27521580466a30127f12172a3278172ad68bc",
+                "sha256:19fa1d56c91341318ac5d417e7b61c56e9a41183946cc70c411341173de02c69",
+                "sha256:2bb0624a8a70834e54dde8feed62ed63b50bad7a1265c40d6403a2ac447bce01",
+                "sha256:42eda9f525a208fbc4f7cecd00fa15c57cc57646c76632b3ba2fe005004f051d",
+                "sha256:44cac8575bf168601424302045234d74e3561fbdbac39b2b54cc1d1d00b70760",
+                "sha256:6de130d0cb78985a5d080e323b86c5ecaf3af82f4890492c05981707852f983c",
+                "sha256:7ae39b11a5f4cec1432d706c21ecc62f9e04d116883178b09671aa29c46f7a47",
+                "sha256:90e56f17755e41b425ad19a08c41dc358fa7bf1226c0f8e54d4d02d556f7af7c",
+                "sha256:b45218c99795803fb8bdbc9435ff7f54e3a591b44cd4c121b02fa83affb61c7c",
+                "sha256:e5e5f855c9bf483ee6cd1eb9a179b740de80cb0ae2988e3fa22309b78e2ea0e7"
             ],
             "index": "pypi",
-            "version": "==0.14.0"
+            "version": "==0.15.2"
         },
         "vine": {
             "hashes": [
@@ -578,7 +628,7 @@
                 "sha256:5b9062d5c0812335c75434bf17ce33d7a20ecfedaa0733faec7379868eb4068a",
                 "sha256:fcd5b3baeeb7fc19b3486ff6d10543099d40ae1f5c9196eae695d1cde1b2f784"
             ],
-            "markers": "python_version >= '3.6'",
+            "index": "pypi",
             "version": "==5.0.2"
         },
         "appdirs": {
@@ -674,58 +724,58 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:08b3ba72bd981531fd557f67beee376d6700fba183b167857038997ba30dd297",
-                "sha256:2757fa64e11ec12220968f65d086b7a29b6583d16e9a544c889b22ba98555ef1",
-                "sha256:3102bb2c206700a7d28181dbe04d66b30780cde1d1c02c5f3c165cf3d2489497",
-                "sha256:3498b27d8236057def41de3585f317abae235dd3a11d33e01736ffedb2ef8606",
-                "sha256:378ac77af41350a8c6b8801a66021b52da8a05fd77e578b7380e876c0ce4f528",
-                "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b",
-                "sha256:3911c2ef96e5ddc748a3c8b4702c61986628bb719b8378bf1e4a6184bbd48fe4",
-                "sha256:3a3c3f8863255f3c31db3889f8055989527173ef6192a283eb6f4db3c579d830",
-                "sha256:3b14b1da110ea50c8bcbadc3b82c3933974dbeea1832e814aab93ca1163cd4c1",
-                "sha256:535dc1e6e68fad5355f9984d5637c33badbdc987b0c0d303ee95a6c979c9516f",
-                "sha256:6f61319e33222591f885c598e3e24f6a4be3533c1d70c19e0dc59e83a71ce27d",
-                "sha256:723d22d324e7997a651478e9c5a3120a0ecbc9a7e94071f7e1954562a8806cf3",
-                "sha256:76b2775dda7e78680d688daabcb485dc87cf5e3184a0b3e012e1d40e38527cc8",
-                "sha256:782a5c7df9f91979a7a21792e09b34a658058896628217ae6362088b123c8500",
-                "sha256:7e4d159021c2029b958b2363abec4a11db0ce8cd43abb0d9ce44284cb97217e7",
-                "sha256:8dacc4073c359f40fcf73aede8428c35f84639baad7e1b46fce5ab7a8a7be4bb",
-                "sha256:8f33d1156241c43755137288dea619105477961cfa7e47f48dbf96bc2c30720b",
-                "sha256:8ffd4b204d7de77b5dd558cdff986a8274796a1e57813ed005b33fd97e29f059",
-                "sha256:93a280c9eb736a0dcca19296f3c30c720cb41a71b1f9e617f341f0a8e791a69b",
-                "sha256:9a4f66259bdd6964d8cf26142733c81fb562252db74ea367d9beb4f815478e72",
-                "sha256:9a9d4ff06804920388aab69c5ea8a77525cf165356db70131616acd269e19b36",
-                "sha256:a2070c5affdb3a5e751f24208c5c4f3d5f008fa04d28731416e023c93b275277",
-                "sha256:a4857f7e2bc6921dbd487c5c88b84f5633de3e7d416c4dc0bb70256775551a6c",
-                "sha256:a607ae05b6c96057ba86c811d9c43423f35e03874ffb03fbdcd45e0637e8b631",
-                "sha256:a66ca3bdf21c653e47f726ca57f46ba7fc1f260ad99ba783acc3e58e3ebdb9ff",
-                "sha256:ab110c48bc3d97b4d19af41865e14531f300b482da21783fdaacd159251890e8",
-                "sha256:b239711e774c8eb910e9b1ac719f02f5ae4bf35fa0420f438cdc3a7e4e7dd6ec",
-                "sha256:be0416074d7f253865bb67630cf7210cbc14eb05f4099cc0f82430135aaa7a3b",
-                "sha256:c46643970dff9f5c976c6512fd35768c4a3819f01f61169d8cdac3f9290903b7",
-                "sha256:c5ec71fd4a43b6d84ddb88c1df94572479d9a26ef3f150cef3dacefecf888105",
-                "sha256:c6e5174f8ca585755988bc278c8bb5d02d9dc2e971591ef4a1baabdf2d99589b",
-                "sha256:c89b558f8a9a5a6f2cfc923c304d49f0ce629c3bd85cb442ca258ec20366394c",
-                "sha256:cc44e3545d908ecf3e5773266c487ad1877be718d9dc65fc7eb6e7d14960985b",
-                "sha256:cc6f8246e74dd210d7e2b56c76ceaba1cc52b025cd75dbe96eb48791e0250e98",
-                "sha256:cd556c79ad665faeae28020a0ab3bda6cd47d94bec48e36970719b0b86e4dcf4",
-                "sha256:ce6f3a147b4b1a8b09aae48517ae91139b1b010c5f36423fa2b866a8b23df879",
-                "sha256:ceb499d2b3d1d7b7ba23abe8bf26df5f06ba8c71127f188333dddcf356b4b63f",
-                "sha256:cef06fb382557f66d81d804230c11ab292d94b840b3cb7bf4450778377b592f4",
-                "sha256:e448f56cfeae7b1b3b5bcd99bb377cde7c4eb1970a525c770720a352bc4c8044",
-                "sha256:e52d3d95df81c8f6b2a1685aabffadf2d2d9ad97203a40f8d61e51b70f191e4e",
-                "sha256:ee2f1d1c223c3d2c24e3afbb2dd38be3f03b1a8d6a83ee3d9eb8c36a52bee899",
-                "sha256:f2c6888eada180814b8583c3e793f3f343a692fc802546eed45f40a001b1169f",
-                "sha256:f51dbba78d68a44e99d484ca8c8f604f17e957c1ca09c3ebc2c7e3bbd9ba0448",
-                "sha256:f54de00baf200b4539a5a092a759f000b5f45fd226d6d25a76b0dff71177a714",
-                "sha256:fa10fee7e32213f5c7b0d6428ea92e3a3fdd6d725590238a3f92c0de1c78b9d2",
-                "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d",
-                "sha256:fac3c432851038b3e6afe086f777732bcf7f6ebbfd90951fa04ee53db6d0bcdd",
-                "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7",
-                "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"
+                "sha256:03ed2a641e412e42cc35c244508cf186015c217f0e4d496bf6d7078ebe837ae7",
+                "sha256:04b14e45d6a8e159c9767ae57ecb34563ad93440fc1b26516a89ceb5b33c1ad5",
+                "sha256:0cdde51bfcf6b6bd862ee9be324521ec619b20590787d1655d005c3fb175005f",
+                "sha256:0f48fc7dc82ee14aeaedb986e175a429d24129b7eada1b7e94a864e4f0644dde",
+                "sha256:107d327071061fd4f4a2587d14c389a27e4e5c93c7cba5f1f59987181903902f",
+                "sha256:1375bb8b88cb050a2d4e0da901001347a44302aeadb8ceb4b6e5aa373b8ea68f",
+                "sha256:14a9f1887591684fb59fdba8feef7123a0da2424b0652e1b58dd5b9a7bb1188c",
+                "sha256:16baa799ec09cc0dcb43a10680573269d407c159325972dd7114ee7649e56c66",
+                "sha256:1b811662ecf72eb2d08872731636aee6559cae21862c36f74703be727b45df90",
+                "sha256:1ccae21a076d3d5f471700f6d30eb486da1626c380b23c70ae32ab823e453337",
+                "sha256:2f2cf7a42d4b7654c9a67b9d091ec24374f7c58794858bff632a2039cb15984d",
+                "sha256:322549b880b2d746a7672bf6ff9ed3f895e9c9f108b714e7360292aa5c5d7cf4",
+                "sha256:32ab83016c24c5cf3db2943286b85b0a172dae08c58d0f53875235219b676409",
+                "sha256:3fe50f1cac369b02d34ad904dfe0771acc483f82a1b54c5e93632916ba847b37",
+                "sha256:4a780807e80479f281d47ee4af2eb2df3e4ccf4723484f77da0bb49d027e40a1",
+                "sha256:4a8eb7785bd23565b542b01fb39115a975fefb4a82f23d407503eee2c0106247",
+                "sha256:5bee3970617b3d74759b2d2df2f6a327d372f9732f9ccbf03fa591b5f7581e39",
+                "sha256:60a3307a84ec60578accd35d7f0c71a3a971430ed7eca6567399d2b50ef37b8c",
+                "sha256:6625e52b6f346a283c3d563d1fd8bae8956daafc64bb5bbd2b8f8a07608e3994",
+                "sha256:66a5aae8233d766a877c5ef293ec5ab9520929c2578fd2069308a98b7374ea8c",
+                "sha256:68fb816a5dd901c6aff352ce49e2a0ffadacdf9b6fae282a69e7a16a02dad5fb",
+                "sha256:6b588b5cf51dc0fd1c9e19f622457cc74b7d26fe295432e434525f1c0fae02bc",
+                "sha256:6c4d7165a4e8f41eca6b990c12ee7f44fef3932fac48ca32cecb3a1b2223c21f",
+                "sha256:6d2e262e5e8da6fa56e774fb8e2643417351427604c2b177f8e8c5f75fc928ca",
+                "sha256:6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135",
+                "sha256:755c56beeacac6a24c8e1074f89f34f4373abce8b662470d3aa719ae304931f3",
+                "sha256:7e40d3f8eb472c1509b12ac2a7e24158ec352fc8567b77ab02c0db053927e339",
+                "sha256:812eaf4939ef2284d29653bcfee9665f11f013724f07258928f849a2306ea9f9",
+                "sha256:84df004223fd0550d0ea7a37882e5c889f3c6d45535c639ce9802293b39cd5c9",
+                "sha256:859f0add98707b182b4867359e12bde806b82483fb12a9ae868a77880fc3b7af",
+                "sha256:87c4b38288f71acd2106f5d94f575bc2136ea2887fdb5dfe18003c881fa6b370",
+                "sha256:89fc12c6371bf963809abc46cced4a01ca4f99cba17be5e7d416ed7ef1245d19",
+                "sha256:9564ac7eb1652c3701ac691ca72934dd3009997c81266807aef924012df2f4b3",
+                "sha256:9754a5c265f991317de2bac0c70a746efc2b695cf4d49f5d2cddeac36544fb44",
+                "sha256:a565f48c4aae72d1d3d3f8e8fb7218f5609c964e9c6f68604608e5958b9c60c3",
+                "sha256:a636160680c6e526b84f85d304e2f0bb4e94f8284dd765a1911de9a40450b10a",
+                "sha256:a839e25f07e428a87d17d857d9935dd743130e77ff46524abb992b962eb2076c",
+                "sha256:b62046592b44263fa7570f1117d372ae3f310222af1fc1407416f037fb3af21b",
+                "sha256:b7f7421841f8db443855d2854e25914a79a1ff48ae92f70d0a5c2f8907ab98c9",
+                "sha256:ba7ca81b6d60a9f7a0b4b4e175dcc38e8fef4992673d9d6e6879fd6de00dd9b8",
+                "sha256:bb32ca14b4d04e172c541c69eec5f385f9a075b38fb22d765d8b0ce3af3a0c22",
+                "sha256:c0ff1c1b4d13e2240821ef23c1efb1f009207cb3f56e16986f713c2b0e7cd37f",
+                "sha256:c669b440ce46ae3abe9b2d44a913b5fd86bb19eb14a8701e88e3918902ecd345",
+                "sha256:c67734cff78383a1f23ceba3b3239c7deefc62ac2b05fa6a47bcd565771e5880",
+                "sha256:c6809ebcbf6c1049002b9ac09c127ae43929042ec1f1dbd8bb1615f7cd9f70a0",
+                "sha256:cd601187476c6bed26a0398353212684c427e10a903aeafa6da40c63309d438b",
+                "sha256:ebfa374067af240d079ef97b8064478f3bf71038b78b017eb6ec93ede1b6bcec",
+                "sha256:fbb17c0d0822684b7d6c09915677a32319f16ff1115df5ec05bdcaaee40b35f3",
+                "sha256:fff1f3a586246110f34dc762098b5afd2de88de507559e63553d7da643053786"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==5.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "version": "==5.4"
         },
         "distlib": {
             "hashes": [
@@ -751,11 +801,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:18994e850ba50c37bcaed4832be8b354d6a06c8fb31f54e0e7ece76d32f69bc8",
-                "sha256:892473bf12e655884132a3a32aca737a3cbefaa34a850ff52d501773a45837bc"
+                "sha256:de7129142a5c86d75a52b96f394d94d96d497881d2aaf8eafe320cdbe8ac4bcc",
+                "sha256:e0dae57c0397629ce13c289f6ddde0204edf518f557bfdb1e56474aa143e77c3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.5.12"
+            "version": "==1.5.14"
         },
         "idna": {
             "hashes": [
@@ -766,11 +816,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
-                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
+                "sha256:2a851a30a1fd847cedd68c7c6bfb90e765db6265852f574e9d88bb40f96924ab",
+                "sha256:31c5c29f17d064cc71bf6a005a8b25b3332787ab2e7362d5d258800ac825f471"
             ],
-            "markers": "python_version < '3.8' and python_version < '3.8'",
-            "version": "==3.3.0"
+            "markers": "python_version < '3.8'",
+            "version": "==3.5.0"
         },
         "iniconfig": {
             "hashes": [
@@ -804,23 +854,31 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0a0d102247c16ce93c97066443d11e2d36e6cc2a32d8ccc1f705268970479324",
-                "sha256:0d34d6b122597d48a36d6c59e35341f410d4abfa771d96d04ae2c468dd201abc",
-                "sha256:2170492030f6faa537647d29945786d297e4862765f0b4ac5930ff62e300d802",
-                "sha256:2842d4fbd1b12ab422346376aad03ff5d0805b706102e475e962370f874a5122",
-                "sha256:2b21ba45ad9ef2e2eb88ce4aeadd0112d0f5026418324176fd494a6824b74975",
-                "sha256:72060bf64f290fb629bd4a67c707a66fd88ca26e413a91384b18db3876e57ed7",
-                "sha256:af4e9ff1834e565f1baa74ccf7ae2564ae38c8df2a85b057af1dbbc958eb6666",
-                "sha256:bd03b3cf666bff8d710d633d1c56ab7facbdc204d567715cb3b9f85c6e94f669",
-                "sha256:c614194e01c85bb2e551c421397e49afb2872c88b5830e3554f0519f9fb1c178",
-                "sha256:cf4e7bf7f1214826cf7333627cb2547c0db7e3078723227820d0a2490f117a01",
-                "sha256:da56dedcd7cd502ccd3c5dddc656cb36113dd793ad466e894574125945653cea",
-                "sha256:e86bdace26c5fe9cf8cb735e7cedfe7850ad92b327ac5d797c656717d2ca66de",
-                "sha256:e97e9c13d67fbe524be17e4d8025d51a7dca38f90de2e462243ab8ed8a9178d1",
-                "sha256:eea260feb1830a627fb526d22fbb426b750d9f5a47b624e8d5e7e004359b219c"
+                "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e",
+                "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064",
+                "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c",
+                "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4",
+                "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97",
+                "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df",
+                "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8",
+                "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a",
+                "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56",
+                "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7",
+                "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6",
+                "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5",
+                "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a",
+                "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521",
+                "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564",
+                "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49",
+                "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66",
+                "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a",
+                "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119",
+                "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506",
+                "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c",
+                "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"
             ],
             "index": "pypi",
-            "version": "==0.790"
+            "version": "==0.812"
         },
         "mypy-extensions": {
             "hashes": [
@@ -838,11 +896,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858",
-                "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.8"
+            "version": "==20.9"
         },
         "pathspec": {
             "hashes": [
@@ -861,19 +919,19 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:6c86d977d00ddc8a60d68eec19f51ef212d9462937acf3ea37c7adec32284ac0",
-                "sha256:ee784c11953e6d8badb97d19bc46b997a3a9eded849881ec587accd8608d74a4"
+                "sha256:16212d1fde2bed88159287da88ff03796863854b04dc9f838a55979325a3d20e",
+                "sha256:399baf78f13f4de82a29b649afd74bef2c4e28eb4f021661fc7f29246e8c7a3a"
             ],
             "index": "pypi",
-            "version": "==2.9.3"
+            "version": "==2.10.1"
         },
         "prompt-toolkit": {
             "hashes": [
-                "sha256:ac329c69bd8564cb491940511957312c7b8959bb5b3cf3582b406068a51d5bb7",
-                "sha256:b8b3d0bde65da350290c46a8f54f336b3cbf5464a4ac11239668d986852e79d5"
+                "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974",
+                "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.0.10"
+            "version": "==3.0.16"
         },
         "py": {
             "hashes": [
@@ -904,16 +962,16 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
             "hashes": [
-                "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8",
-                "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"
+                "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9",
+                "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"
             ],
             "index": "pypi",
-            "version": "==6.2.1"
+            "version": "==6.2.2"
         },
         "pytest-celery": {
             "hashes": [
@@ -925,11 +983,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191",
-                "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
+                "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7",
+                "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"
             ],
             "index": "pypi",
-            "version": "==2.10.1"
+            "version": "==2.11.1"
         },
         "pytest-timeout": {
             "hashes": [
@@ -941,28 +999,37 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4",
-                "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"
+                "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da",
+                "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"
             ],
-            "version": "==2020.5"
+            "version": "==2021.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
-                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
-                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
-                "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e",
-                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
-                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
-                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
-                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
-                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
-                "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a",
-                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
-                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
-                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"
             ],
-            "version": "==5.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
         },
         "regex": {
             "hashes": [
@@ -1023,7 +1090,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -1031,7 +1098,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "typed-ast": {
@@ -1080,11 +1147,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08",
-                "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"
+                "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80",
+                "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.2"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "version": "==1.26.3"
         },
         "vine": {
             "hashes": [
@@ -1096,11 +1163,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c",
-                "sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"
+                "sha256:147b43894e51dd6bba882cf9c282447f780e2251cd35172403745fc381a0a80d",
+                "sha256:2be72df684b74df0ea47679a7df93fd0e04e72520022c57b479d8f881485dbe3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.2.2"
+            "version": "==20.4.2"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Run non-dockerized web server
 pipenv run uvicorn terachem_cloud.main:app --reload
 ```
 
+### Development on Fire (or any machine with GPUs)
+Developing on a machine with GPUs means you can run `TeraChem` in server mode inside the docker worker. For development purposes, it's easiest to startup the `docker-compose` stack sans worker and then run the worker with `docker run` directly since `docker-compose` lacks good GPU support.
+
+```sh
+docker-compose -f docker/docker-compose.base.yaml -f docker/docker-compose.local.yaml up -d --build web-server mq redis
+
+docker build -t tcc_celery_worker -f docker/celeryworker.dockerfile . && docker run -d --rm -v /data/coltonbh/license.key:/terachem/license.key -v /data/coltonbh:/scratch --net=host --gpus 2 -e TERACHEM_PBS_HOST='127.0.0.1' -e TERACHEM_PBS_PORT='11111'  --name tcc_worker tcc_celery_worker
+
+# To stop worker
+docker stop tcc_worker
+```
+
 ### Manage environment and Auth0 for local development
 
 Settings are managed in `terachem_cloud/config` and the `Settings` object will automatically look for environment variables found in both the environment and a `.env` file. If you need authentication to work for local development add the following variables to a `.env` file in the root directory with their corresponding values. These values are not required for tests to run correctly, though authentication-required endpoints will not work if hand-testing since a mocked auth system for local development has not been created.

--- a/docker/celeryworker.dockerfile
+++ b/docker/celeryworker.dockerfile
@@ -1,4 +1,5 @@
 # Dockerfile for TeraChem Cloud Worker
+# Contains celery worker and all CPU-only QC Packages
 FROM continuumio/miniconda3:4.8.2
 
 # https://github.com/awslabs/amazon-sagemaker-examples/issues/319

--- a/docker/context.dev
+++ b/docker/context.dev
@@ -1,4 +1,4 @@
-# bash-able variables for docker-compose.template.yaml
+# bash-able variables for docker-compose.web.yaml
 
 WEBSERVER_TRAEFIK_HOST=\`tcc.dev.mtzlab.com\`
 

--- a/docker/context.prod
+++ b/docker/context.prod
@@ -1,4 +1,4 @@
-# bash-able variables for docker-compose.template.yaml
+# bash-able variables for docker-compose.web.yaml
 
 WEBSERVER_TRAEFIK_HOST=\`tcc.mtzlab.com\`
 

--- a/docker/docker-compose.local.yaml
+++ b/docker/docker-compose.local.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - 8000:8000
     environment:
-      # Connect to rabbit and redis over docker network instead of locahost
+      # Connect to rabbit and redis over docker network instead of localhost
       - CELERY_BROKER_CONNECTION_STRING=amqp://mq
       - CELERY_BACKEND_CONNECTION_STRING=redis://redis/0
     env_file:
@@ -29,16 +29,14 @@ services:
       - CELERY_BACKEND_CONNECTION_STRING=redis://redis/0
     env_file:
       - ../.env
-    volumes:
-      - ../terachem_cloud:/code/terachem_cloud
 
   mq:
     ports:
-      # Open rabbit to locahost for dev container access
+      # Open rabbit to localhost for dev container access
       - 5672:5672
       - 15672:15672
 
   redis:
     ports:
-      # Open redis to locahost for dev container access
+      # Open redis to localhost for dev container access
       - 6379:6379

--- a/docker/docker-compose.web.yaml
+++ b/docker/docker-compose.web.yaml
@@ -16,7 +16,7 @@ services:
           memory: 512M
       update_config:
         parallelism: 1
-        delay: 10s
+        order: start-first
       labels:
         - traefik.enable=true
         - traefik.docker.network=traefik-public

--- a/docker/docker-compose.worker.yaml
+++ b/docker/docker-compose.worker.yaml
@@ -2,14 +2,32 @@
 # source context.{dev | prod}
 # eval "echo \"$(cat $(pwd)/docker-compose.worker.yaml)\"" > output.yaml
 
-version: \"3.3\" # XStream has older docker version so 3.3 is necessary
+version: \"3.7\" #XStream can only support up to 3.7. Using docker 18.06.1-ce
 
 services:
   worker:
     image: ${FULL_IMAGE_NAME}
     env_file: worker.env
+    secrets:
+      - source: terachem_licence
+        target: /terachem/license.key
+    # According to the docs it appears each service container will get its own, unshared docker volume.
+    # This is what we want since we don't want servers starting up at the same time and creating the
+    # same server directories and then having issues when each puts "job_1" in the same folder and
+    # begin colliding. Default docker directory is on /lstror on XStream which is a local scratch
+    # directory. Need to make sure that containers on the same host don't share the volume though...
+    # https://docs.docker.com/storage/volumes/#start-a-service-with-volumes
+    volumes:
+      - scratch:/scratch
     deploy:
       replicas: ${WORKER_REPLICAS}
       update_config:
         parallelism: 1
-        delay: 10s
+
+secrets:
+  terachem_licence:
+    external: true
+
+volumes:
+  scratch:
+

--- a/docker/docker-compose.xstream.dev.yaml
+++ b/docker/docker-compose.xstream.dev.yaml
@@ -1,0 +1,90 @@
+# A bash-able template that will fill with variables if correct environment variables are loaded
+# source context.{dev | prod}
+# eval echo "" > output.yaml
+
+# XStream dev worker configuration
+# For notes on setup see docs/development/architecture.md#XStream-Architecture-Setup
+
+version: \"3.7\" #XStream can only support up to 3.7. Using docker 18.06.1-ce
+
+# Default images and setup for worker containers
+x-default-worker: &default-worker
+  image: ${FULL_IMAGE_NAME}
+  env_file: worker.env
+  environment:
+      - TERACHEM_PBS_PORT=11111
+  volumes:
+    - tcc-dev-scratch:/scratch
+
+# Default images and setup for terachem containers
+x-default-terachem: &default-terachem
+  image: mtzgroup/terachem:1.9-2021.02-dev-arch-sm_37-sm_52-sm_61-sm_70
+  secrets:
+    - source: terachem_licence
+      target: /terachem/license.key
+  volumes:
+    - tcc-dev-scratch:/scratch
+
+# Deploy to xs7-0001 node
+x-xs7-0001-deploy: &xs7-0001
+  placement:
+    constraints:
+      - "node.hostname==xs7-0001"
+
+# Celery workers on xs7-0001
+x-xs7-0001-worker: &xs7-0001-worker
+  <<: *default-worker
+  deploy:
+    <<: *xs7-0001
+
+# TeraChem servers on xs7-0001
+x-xs7-0001-terachem: &xs7-0001-terachem
+  <<: *default-terachem
+  deploy:
+    <<: *xs7-0001
+
+# Deploy to xs7-0002 node
+x-xs7-0002-deploy: &xs7-0002
+  placement:
+    constraints:
+      - "node.hostname==xs7-0002"
+
+# Celery workers on xs7-0002
+x-xs7-0002-worker: &xs7-0002-worker
+  <<: *default-worker
+  deploy:
+    <<: *xs7-0002
+
+# TeraChem servers on xs7-0002
+x-xs7-0002-terachem: &xs7-0002-terachem
+  <<: *default-terachem
+  deploy:
+    <<: *xs7-0002
+
+services:
+  # Pod 1: xs7-0001, GPU 0
+  xs7-0001-worker-0: # name specified via {hostname}-worker-{gpu_number}
+    <<: *xs7-0001-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0001-terachem-0 # Must match TeraChem service name below
+  xs7-0001-terachem-0: # name specified via {hostname}-terachem-gpu_number}
+    <<: *xs7-0001-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=0
+
+  # Pod 2: xs7-0002, GPU 0
+  xs7-0002-worker-0:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-0
+  xs7-0002-terachem-0:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=0
+
+secrets:
+  terachem_licence:
+    external: true
+
+volumes:
+  tcc-dev-scratch:

--- a/docker/docker-compose.xstream.prod.yaml
+++ b/docker/docker-compose.xstream.prod.yaml
@@ -1,0 +1,250 @@
+# A bash-able template that will fill with variables if correct environment variables are loaded
+# source context.{dev | prod}
+# eval echo "" > output.yaml
+
+# XStream dev worker configuration
+# For notes on setup see docs/development/architecture.md#XStream-Architecture-Setup
+
+version: \"3.7\" #XStream can only support up to 3.7. Using docker 18.06.1-ce
+
+# Default images and setup for worker containers
+x-default-worker: &default-worker
+  image: ${FULL_IMAGE_NAME}
+  env_file: worker.env
+  environment:
+      - TERACHEM_PBS_PORT=11111
+  volumes:
+    - tcc-prod-scratch:/scratch
+
+# Default images and setup for terachem containers
+x-default-terachem: &default-terachem
+  image: mtzgroup/terachem:1.9-2021.02-dev-arch-sm_37-sm_52-sm_61-sm_70
+  secrets:
+    - source: terachem_licence
+      target: /terachem/license.key
+  volumes:
+    - tcc-prod-scratch:/scratch
+
+# Deploy to xs7-0001 node
+x-xs7-0001-deploy: &xs7-0001
+  placement:
+    constraints:
+      - "node.hostname==xs7-0001"
+
+# Celery workers on xs7-0001
+x-xs7-0001-worker: &xs7-0001-worker
+  <<: *default-worker
+  deploy:
+    <<: *xs7-0001
+
+# TeraChem servers on xs7-0001
+x-xs7-0001-terachem: &xs7-0001-terachem
+  <<: *default-terachem
+  deploy:
+    <<: *xs7-0001
+
+# Deploy to xs7-0002 node
+x-xs7-0002-deploy: &xs7-0002
+  placement:
+    constraints:
+      - "node.hostname==xs7-0002"
+
+# Celery workers on xs7-0002
+x-xs7-0002-worker: &xs7-0002-worker
+  <<: *default-worker
+  deploy:
+    <<: *xs7-0002
+
+# TeraChem servers on xs7-0002
+x-xs7-0002-terachem: &xs7-0002-terachem
+  <<: *default-terachem
+  deploy:
+    <<: *xs7-0002
+
+services:
+  # xs7-0001 Pod 1: GPU 1; NOTE: GPU 0 used by dev
+  xs7-0001-worker-1: # name specified via {hostname}-worker-{gpu_number}
+    <<: *xs7-0001-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0001-terachem-1 # Must match TeraChem service name below
+  xs7-0001-terachem-1: # name specified via {hostname}-terachem-gpu_number}
+    <<: *xs7-0001-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=1
+
+  # xs7-0001 Pod 2: GPU 2
+  xs7-0001-worker-2: # name specified via {hostname}-worker-{gpu_number}
+    <<: *xs7-0001-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0001-terachem-2 # Must match TeraChem service name below
+  xs7-0001-terachem-2: # name specified via {hostname}-terachem-gpu_number}
+    <<: *xs7-0001-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=2
+
+  # xs7-0001 Pod 3: GPU 3
+  xs7-0001-worker-3: # name specified via {hostname}-worker-{gpu_number}
+    <<: *xs7-0001-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0001-terachem-3 # Must match TeraChem service name below
+  xs7-0001-terachem-3: # name specified via {hostname}-terachem-gpu_number}
+    <<: *xs7-0001-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=3
+
+  # xs7-0002 Pod 1: GPU 1; NOTE: GPU 0 used by dev
+  xs7-0002-worker-1:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-1
+  xs7-0002-terachem-1:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=1
+
+  # xs7-0002 Pod 2: GPU 2
+  xs7-0002-worker-2:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-2
+  xs7-0002-terachem-2:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=2
+
+  # xs7-0002 Pod 3: GPU 3
+  xs7-0002-worker-3:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-3
+  xs7-0002-terachem-3:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=3
+
+  # xs7-0002 Pod 4: GPU 4
+  xs7-0002-worker-4:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-4
+  xs7-0002-terachem-4:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=4
+
+  # xs7-0002 Pod 5: GPU 5
+  xs7-0002-worker-5:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-5
+  xs7-0002-terachem-5:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=5
+
+  # xs7-0002 Pod 6: GPU 6
+  xs7-0002-worker-6:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-6
+  xs7-0002-terachem-6:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=6
+
+  # xs7-0002 Pod 7: GPU 7
+  xs7-0002-worker-7:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-7
+  xs7-0002-terachem-7:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=7
+
+  # xs7-0002 Pod 8: GPU 8
+  xs7-0002-worker-8:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-8
+  xs7-0002-terachem-8:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=8
+
+  # xs7-0002 Pod 9: GPU 9
+  xs7-0002-worker-9:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-9
+  xs7-0002-terachem-9:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=9
+
+  # xs7-0002 Pod 10: GPU 10
+  xs7-0002-worker-10:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-10
+  xs7-0002-terachem-10:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=10
+
+  # xs7-0002 Pod 11: GPU 11
+  xs7-0002-worker-11:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-11
+  xs7-0002-terachem-11:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=11
+
+  # xs7-0002 Pod 12: GPU 12
+  xs7-0002-worker-12:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-12
+  xs7-0002-terachem-12:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=12
+
+  # xs7-0002 Pod 13: GPU 13
+  xs7-0002-worker-13:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-13
+  xs7-0002-terachem-13:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=13
+
+  # xs7-0002 Pod 14: GPU 14
+  xs7-0002-worker-14:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-14
+  xs7-0002-terachem-14:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=14
+
+  # xs7-0002 Pod 15: GPU 15
+  xs7-0002-worker-15:
+    <<: *xs7-0002-worker
+    environment:
+      - TERACHEM_PBS_HOST=xs7-0002-terachem-15
+  xs7-0002-terachem-15:
+    <<: *xs7-0002-terachem
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=15
+
+secrets:
+  terachem_licence:
+    external: true
+
+volumes:
+  tcc-prod-scratch:

--- a/docker/server.dockerfile
+++ b/docker/server.dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Colton Hicks <colton@coltonhicks.com>"
 # Install system packages
 # Need gcc and python3-dev for python psutil package
 # https://github.com/giampaolo/psutil/blob/master/INSTALL.rst
-RUN apt-get update && apt-get install -y gcc make python3-dev && pip install pipenv
+RUN apt-get update && apt-get install -y gcc git make python3-dev && pip install pipenv
 
 # Install application
 WORKDIR /code/

--- a/docker/worker_and_terachem.dockerfile
+++ b/docker/worker_and_terachem.dockerfile
@@ -1,0 +1,56 @@
+# Dockerfile for TeraChem Cloud Worker with TeraChem baked into the image
+# Given that we are running TeraChem in server mode on TCC there are many
+# reasons to package it separately from the open source packages. 
+# See docker/development/architecture.md. Keeping this file for a bit until 
+# I decide it is no longer necessary
+FROM mtzgroup/terachem:1.9-2021.02-dev-arch-sm_37-sm_52-sm_61-sm_70
+
+# https://github.com/awslabs/amazon-sagemaker-examples/issues/319
+ENV PYTHONUNBUFFERED=1
+LABEL maintainer="Colton Hicks <colton@coltonhicks.com>"
+
+# Install System Packages 
+# Need gcc and python3-dev for python psutil package; https://github.com/giampaolo/psutil/blob/master/INSTALL.rst
+RUN yum update -y && \
+    yum install -y \
+    wget \
+    python3-dev \
+    gcc \
+    git \
+    && yum clean all
+
+# Install Conda
+# Modified from https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/debian/Dockerfile
+ENV PATH /opt/conda/bin:$PATH
+
+# Leave these args here to better use the Docker build cache
+ARG CONDA_VERSION=py37_4.8.2
+ARG CONDA_MD5=87e77f097f6ebb5127c77662dfc3165e
+
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh -O miniconda.sh && \
+    echo "${CONDA_MD5}  miniconda.sh" > miniconda.md5 && \
+    if ! md5sum --status -c miniconda.md5; then exit 1; fi && \
+    mkdir -p /opt && \
+    sh miniconda.sh -b -p /opt/conda && \
+    rm miniconda.sh miniconda.md5 && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc && \
+    find /opt/conda/ -follow -type f -name '*.a' -delete && \
+    find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+    /opt/conda/bin/conda clean -afy
+
+
+# Install psi4 and pipenv
+RUN conda install psi4 -c psi4 && pip install pipenv
+
+# Install application
+WORKDIR /code/
+COPY Pipfile Pipfile.lock ./
+# Install to system python, no need for pipenv virtual env; system python is Miniconda version now
+RUN pipenv install --system --deploy
+COPY terachem_cloud/workers/ terachem_cloud/workers/
+COPY terachem_cloud/workers/worker-start.sh .
+RUN chmod +x /code/worker-start.sh
+
+CMD ["bash", "/code/worker-start.sh"]

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,40 @@
+# Architecture
+
+## Core Decisions and Justifications
+
+### Dockerize TeraChem Separately from Celery Worker
+
+Running TeraChem in server mode so that it is callable from the celery worker image could be accomplished one of two ways:
+
+1. Run TeraChem in the background of the celery worker container
+2. Run TeraChem in a separate container and network it so that it is accessible by the celery worker
+
+Option #2 has been selected given the following justifications:
+
+Pros:
+
+- TeraChem crashes a lot. When it crashes, server mode dies. If we are running TeraChem in the background of the worker container we need an additional process (such as `systemd` or `supervisord`) to monitor TeraChem and restart it after crashing. Various other approaches are described [here](https://docs.docker.com/config/containers/multi-service_container/). Breaking the Docker rule of "one container one process" divorces us from all the benefits of having docker monitor the status of the container and restart it when the main process dies. Instead, we have to add the additional complexity of our own process monitors in each container.
+- I can maintain TeraChem repos/images separately from the celery worker codes. Each has a very different lifecycle and build/runtime requirements. Keeping GPU/CPU codes separately seems wise.
+- Easier to run non-GPU accelerated workers given CPU-only celery workers.
+- Smaller worker images.
+- Not packaging TeraChem into worker images where it may not be used on various machines.
+- TeraChem runtime requirements are quite unique (CUDA, GPUs, old libraries). I don't want to marry these requirements to the worker containers themselves which may benefit from dramatically different runtime requirements.
+- All open source software can live in a single image (celery worker + other QC packages) separate from TeraChem which may require licenses.
+- The TeraChem server mode client assumes a server anywhere in the world--opening the possibility of running TeraChem farms separate from my workers is interesting.
+- Can scale CPU and GPU workloads separately and with more flexibility.
+- Cleaner separation of concerns--one container to receive and execute tasks, one container to make available and execute TeraChem workloads.
+
+Cons:
+
+- Shared data access between the celery worker and TeraChem container becomes slightly more complicated. I can no longer assume access to the same filesystem. However, sharing data between containers has many well documented solutions. One such solution is sharing a docker volume which may write to a local scratch directory or a network file system if greater persistence is required.
+- 2x the number of docker containers running to power the backend.
+
+### XStream Worker Setup
+
+- There is currently (Feb 22, 2021) no supported format for gpu specifications in the docker-compose 3 spec. As a result, there is no equivalent feature to k8's experimental GPU scheduler (https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/deploying-nvidia-gpu-device-plugin). Therefore, each TeraChem instance must be uniquely declared with hardcoded references to the GPUs it will consume using NVIDA_VISIBLE_DEVICES.
+- Due to this constraint, there is little advantage to having a shared template between the dev and prod environments. Each is simply declared using hard-coded parameters.
+- Each TeraChem instance starts a server that creates a root directory based upon the timestamp (down to the nearest second) of its startup time. Since we will have up to 16 services running on the same node it is possible that some will startup at the same time. This would result in shared directories and multiple TeraChem instances writing on top of each other to the same directories. To avoid this each TeraChem instance is assigned a unique docker volume for its scratch work.
+- The $LSTOR directory on XStream is used for local scratch work (http://xstream.stanford.edu/docs/storage/). This is where docker creates volumes. We have 480GB per node of scratch space available on $LSTOR. We probably want to monitor this space from time-to-time and make sure it isn't filled up.
+- If we ever want to use network storage to have greater persistence for scratch files see https://docs.docker.com/storage/volumes/#start-a-service-with-volumes as a reference and look into the "cloud-stor" NFS Stefan previously used for TCC on XStream.
+- Since we have to hard-code the GPUs that each TeraChem instance will consume we must also hard-code the nodes they run on so that we don't get two TeraChem instances on a single node trying to consume the same GPUs.
+- When a TeraChem server starts up it creates a root directory like `server_2021-01-28-17.14.46` in its `scratch` directory where it writes data. This path is created based on the server start time. Since it is very possible that two servers will startup at the same time on a cluster there is a possibility for collision. The current TC server will crash if a directory already exists with its desired timestamp. Since docker will restart servers upon failure this problem is "solved" in that each wave of TeraChem startups will have collisions, the second server to startup will see this directory and crash, restart, and thereby generate a new timestamp for its scratch output.

--- a/docs/development/auth.md
+++ b/docs/development/auth.md
@@ -1,6 +1,8 @@
 # Authentication and Authorization
 
-## Choices and Justifications
+## Core Decisions and Justifications
+
+### Use Auth0 to provide auth
 
 - Auth is complicated. We do not want to roll our own auth servers. We are using [Auth0](https://auth0.com) as our Authentication Server and will follow [OAuth 2.0](https://oauth.net/2/) protocols for authentication.
 - Read up on FastAPI's [Security](https://fastapi.tiangolo.com/tutorial/security/) and [Advanced Security](https://fastapi.tiangolo.com/advanced/security/) documentation to better understand how to implement OAuth2 flows in FastAPI.

--- a/terachem_cloud/main.py
+++ b/terachem_cloud/main.py
@@ -1,4 +1,6 @@
 """Main module for the FastAPI app. Also contains convenience paths that route """
+from typing import Optional
+
 from fastapi import FastAPI, Security
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -19,7 +21,7 @@ tags_metadata = [
         "description": "Submit compute requests and obtain results.",
     },
     {
-        "name": "default",
+        "name": "hello world",
         "description": "Try out the interactive docs using this endpoint!",
     },
 ]
@@ -52,9 +54,9 @@ async def index():
     return RedirectResponse("/docs")
 
 
-@app.get("/hello-world")
-async def hello_world():
-    return {"Welcome to": "TeraChem Cloud"}
+@app.get("/hello-world", tags=["hello world"])
+async def hello_world(name: Optional[str] = None):
+    return f"Welcome to TeraChem Cloud, {name or 'friend'}"
 
 
 @app.get("/signup", include_in_schema=False)

--- a/terachem_cloud/workers/tasks.py
+++ b/terachem_cloud/workers/tasks.py
@@ -38,6 +38,18 @@ celery_app.conf.update(
     worker_concurrency=1,
 )
 
+# May need to set this for future amqp releases >5.0.2
+# NOTE: Setting this value means celery will change ports for AMPQ to 5671 by default
+# this means I should probably only set this value if I am not running locally
+# if "ampqs" in settings.celery_broker_connection_string:
+#     celery_app.conf.update(
+#         broker_use_ssl={
+#             # Do not verify broker certificate on client. Since Traefik is dynamically
+#             # assigning SSL certs, client-side verification is not possible
+#             "cert_reqs": ssl.CERT_NONE,
+#         },
+#     )
+
 
 @celery_app.task
 def compute(atomic_input: AtomicInput, engine: str) -> AtomicResult:

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -42,18 +42,18 @@ def test_compute_and_result(settings, client, fake_auth, atomic_input):
             f"{settings.api_v1_str}/compute/result/{task_id}",
         )
         response = result.json()
-        return response["status"], response["atomic_result"]
+        return response["status"], response["result"]
 
-    status, atomic_result = _get_result(task_id)
+    status, result = _get_result(task_id)
 
     assert status == "PENDING" or status == "STARTED"
     # No result while computation is happening
-    assert atomic_result is None
+    assert result is None
 
     # Check that work gets done, AtomicResult-compatible data is returned
     while status in {"PENDING", "STARTED"}:
-        status, atomic_result = _get_result(task_id)
+        status, result = _get_result(task_id)
         sleep(1)
 
     assert status == "SUCCESS"
-    assert isinstance(AtomicResult(**atomic_result), AtomicResult)
+    assert isinstance(AtomicResult(**result), AtomicResult)


### PR DESCRIPTION
Add TeraChem (via protobuf server) to the TeraChem cloud stack.

- Closes #7 
  - CI/CD updated for upfront approvals (no need to wait for tests to finish but downstream tests still depend upon successful tests passing), and a single build step for web and workers.
- Closes #22 
  - Changed return result on `/compute/result/{task_id}` to return a `TaskResult` which contains status and either an `AtomicResult` or `FailedOperation` object depending on if exceptions were raised. Modified celery status to change SUCCESS -> FAILURE if `FailedOperation` returned by `qcengine.compute()`.
- Closes #9 
  - This BIG ONE! Got TeraChem dockerized and functioning inside the TCC environment :)
