### PR TITLE
Feature upgrade fixes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,14 +17,12 @@ pytest-timeout = "*"
 autoflake = "*"
 
 [packages]
-fastapi = "*"
 python-jose = {extras = ["cryptography"], version = "*"}
 python-multipart = "*"
 httpx = "*"
 python-dotenv = "*"
 gunicorn = "*"
 uvicorn = "*"
-qcelemental = "*"
 uvloop = "*"
 httptools = "*"
 typing-extensions = "*"
@@ -35,6 +33,8 @@ geometric = {ref = "feature-logging-bug-fix", git = "https://github.com/coltonbh
 tcpb = ">=0.8.0"
 celery = {extras = ["redis"], version = "*"}
 cached-property = "*"
+qcelemental = "==0.20.0"
+fastapi = "==0.65.1"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0caeb1214875bc8d8fbb69e18f2f2bb1632281582b3fade56ec009a92e31ac06"
+            "sha256": "e9fe978e4279c63107afd5998954fc4038a16dfb195c318d482fec35ff950df8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -144,7 +144,7 @@
                 "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
                 "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.4"
         },
         "click": {
@@ -202,16 +202,16 @@
                 "sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676",
                 "sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.17.0"
         },
         "fastapi": {
             "hashes": [
-                "sha256:644bb815bae326575c4b2842469fb83053a4b974b82fa792ff9283d17fbbd99d",
-                "sha256:94d2820906c36b9b8303796fb7271337ec89c74223229e3cfcf056b5a7d59e23"
+                "sha256:478b7e0cbb52c9913b9903d88ae14195cb8a479c4596e0b2f2238d317840a7dc",
+                "sha256:7619282fbce0ec53c7dfa3fa262280c00ace9f6d772cfd06e4ab219dce66985e"
             ],
             "index": "pypi",
-            "version": "==0.68.1"
+            "version": "==0.65.1"
         },
         "geometric": {
             "git": "https://github.com/coltonbh/geomeTRIC.git",
@@ -509,7 +509,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "python-dotenv": {
@@ -582,11 +582,11 @@
         },
         "qcelemental": {
             "hashes": [
-                "sha256:68881df5fc1b8d4b7859ac50f1a4631210243ad97b59176a6ecdded51d3a6cac",
-                "sha256:e4ea679575537877f837c8687014fabcb6f624ffb0b49cb8a1919271b4f2745a"
+                "sha256:83303170d361552510045da4eb4baec8eb10e9e072a0e69a5c073057f6e4871e",
+                "sha256:d11ecdda4120296508363e3b893d1da2019ae812781a814f4292a9eacce03b90"
             ],
             "index": "pypi",
-            "version": "==0.21.0"
+            "version": "==0.20.0"
         },
         "qcengine": {
             "git": "https://github.com/mtzgroup/QCEngine.git",
@@ -614,7 +614,7 @@
                 "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
                 "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
             ],
-            "markers": "python_full_version >= '3.5.0' and python_version < '4'",
+            "markers": "python_version >= '3.5' and python_version < '4'",
             "version": "==4.7.2"
         },
         "six": {
@@ -622,7 +622,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sniffio": {
@@ -630,7 +630,7 @@
                 "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663",
                 "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==1.2.0"
         },
         "soupsieve": {
@@ -797,7 +797,7 @@
                 "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b",
                 "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.4"
         },
         "click": {
@@ -1072,7 +1072,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -1208,7 +1208,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -1216,7 +1216,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {


### PR DESCRIPTION
An updated version of FastAPI didn't like QCElemental's new definitions on `Molecule.connectivity.items.items`. Pegged a few dependencies and got things working again to support python 3.9.5+.