### PR TITLE
Feature wavefunction for parallel tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
         "dtype",
         "freqs",
         "httpx",
+        "kombu",
         "qcel",
         "qcelemental",
         "qcengine",

--- a/Pipfile
+++ b/Pipfile
@@ -30,7 +30,7 @@ aiofiles = "*"
 pyberny = "*"
 qcengine = {ref = "feature-terachem-frontend-harness", git = "https://github.com/coltonbh/QCEngine.git"}
 geometric = {ref = "feature-logging-bug-fix", git = "https://github.com/coltonbh/geomeTRIC.git"}
-tcpb = ">=0.10.0"
+tcpb = ">=0.10.1"
 celery = {extras = ["redis"], version = "*"}
 cached-property = "*"
 qcelemental = "==0.24.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "56068be65d38c0d2684b6ecd6dad7256a9ea0024945d7ad82ddaa0cbfd5836ed"
+            "sha256": "1c54bda0ec177b9a8194827ad92033ec7d649fd11ca71f93c70ab41f887bbe3a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -157,7 +157,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "click": {
@@ -173,7 +173,7 @@
                 "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
                 "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.2'",
             "version": "==0.3.0"
         },
         "click-plugins": {
@@ -328,7 +328,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "kombu": {
@@ -660,7 +660,7 @@
                 "sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17",
                 "sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==4.8"
         },
         "setuptools": {
@@ -684,7 +684,7 @@
                 "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663",
                 "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==1.2.0"
         },
         "soupsieve": {
@@ -705,11 +705,11 @@
         },
         "tcpb": {
             "hashes": [
-                "sha256:27b551b0cb636b25f189d6522f4867500a7cad7ab11929feee7310e35c2d2089",
-                "sha256:373a5b38f7df36b23a9c9031942facd0f13bfe8bb33259e2f84ab36b86b17759"
+                "sha256:6a604cc628670e6f23c7ddc0f131003cff5a1faca424a62f26fc199aa660d9a0",
+                "sha256:cb7d4ac342b0502005be9e40d3f0e9466f64f4f95fb4d20c3033579d7d59af33"
             ],
             "index": "pypi",
-            "version": "==0.10.0"
+            "version": "==0.10.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -926,7 +926,7 @@
                 "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                 "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==2.0.12"
         },
         "click": {
@@ -942,7 +942,7 @@
                 "sha256:a0713dc7a1de3f06bc0df5a9567ad19ead2d3d5689b434768a6145bff77c0667",
                 "sha256:f184f0d851d96b6d29297354ed981b7dd71df7ff500d82fa6d11f0856bee8035"
             ],
-            "markers": "python_version < '4' and python_full_version >= '3.6.2'",
+            "markers": "python_version < '4.0' and python_full_version >= '3.6.2'",
             "version": "==0.3.0"
         },
         "click-plugins": {
@@ -1045,7 +1045,7 @@
                 "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                 "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
-            "markers": "python_full_version >= '3.5.0'",
+            "markers": "python_version >= '3.5'",
             "version": "==3.3"
         },
         "iniconfig": {
@@ -1344,11 +1344,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c",
-                "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"
+                "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66",
+                "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.4"
+            "version": "==20.14.0"
         },
         "wcwidth": {
             "hashes": [

--- a/terachem_cloud/workers/tasks.py
+++ b/terachem_cloud/workers/tasks.py
@@ -87,6 +87,7 @@ def compute_procedure(
     return qcng.compute_procedure(input, procedure, raise_error=raise_error)
 
 
+# TODO: Work out this task...
 @celery_app.task
 def ar_wfn_to_ai(
     result: Union[AtomicResult, FailedOperation],
@@ -125,12 +126,13 @@ def ar_wfn_to_ai(
             extras[TCFEKeywords.ca0] = result.native_files[TCFEKeywords.ca0]
             extras[TCFEKeywords.cb0] = result.native_files[TCFEKeywords.cb0]
 
-        return AtomicInput(
-            molecule=result.molecule,
-            driver=driver,
-            model=result.model,
-            keywords=result.keywords,
-        )
+    return AtomicInput(
+        molecule=result.molecule,
+        driver=driver,
+        model=result.model,
+        keywords=result.keywords,
+        extras=extras,
+    )
 
 
 @celery_app.task

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -221,7 +221,7 @@ def test_compute_procedure_group_limits(
     assert job_submission.status_code == status_codes.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
-@pytest.mark.skip  # Comment out to run test
+# @pytest.mark.skip  # Comment out to run test
 # NOTE: Comment out and run when an available worker has access to terachem_pbs so it
 # doesn't take forever.
 @pytest.mark.parametrize(
@@ -230,13 +230,13 @@ def test_compute_procedure_group_limits(
         (
             "hessian",
             {"method": "HF", "basis": "sto-3g"},
-            {"tcc_kwargs": {"gradient_engine": "psi4"}},
+            {"tcc_kwargs": {"gradient_engine": "terachem_fe"}},
             False,
         ),
         (
             "hessian",
             {"method": "HF", "basis": "sto-3g"},
-            {"tcc_kwargs": {"gradient_engine": "psi4"}},
+            {"tcc_kwargs": {"gradient_engine": "terachem_fe"}},
             True,
         ),
         (
@@ -244,7 +244,7 @@ def test_compute_procedure_group_limits(
             {"method": "HF", "basis": "sto-3g"},
             {
                 "tcc_kwargs": {
-                    "gradient_engine": "psi4",
+                    "gradient_engine": "terachem_fe",
                     "energy": 1.5,
                     "temperature": 310,
                     "pressure": 1.2,

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -221,7 +221,7 @@ def test_compute_procedure_group_limits(
     assert job_submission.status_code == status_codes.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
-# @pytest.mark.skip  # Comment out to run test
+@pytest.mark.skip  # Comment out to run test
 # NOTE: Comment out and run when an available worker has access to terachem_pbs so it
 # doesn't take forever.
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hacking attempt to look at how to initially compute the wave function for distributed algorithms server-side without client input. Not sure if this will work out to be straightforward or relatively difficult.

Key difficulties thus far:
1. Need to convert `task_canvas._gradient_inputs` to be a celery task that runs after an initial energy function that creates the wave function. 
2. Need to figure out how to call a celery group task on the return values of `_gradient_inputs` task that will return an array. Essentially, need to execute the return values as a group in parallel.

Workflow:
1. Perform initial energy calculation that requests a wave function
2. Pass this energy calculation to a task version of `_gradient_inputs` so that it generates the gradient calculations with the wave function data
3. Pass this array of gradient AtomicInputs to a celery group call and have them execute in parallel (not clear how to do this yet...)
4. Pass these gradients to the hessian tasks to create a hessian (this part remains unchanged)

Since the same feature can be accomplished by a user simply generating an initial energy calculation and then passing this to the existing algos this feature is sort of "extra" and based on difficulty I may not fully implement it.