### PR TITLE
Remove web server docker memory constraings. Increase worker timeout …

### DIFF
--- a/docker/docker-compose.web.yaml
+++ b/docker/docker-compose.web.yaml
@@ -10,10 +10,6 @@ services:
       - traefik-public
     env_file: server.env
     deploy:
-      resources:
-        limits:
-          cpus: \"0.5\"
-          memory: 512M
       update_config:
         parallelism: 1
         order: start-first

--- a/docker/server.dockerfile
+++ b/docker/server.dockerfile
@@ -24,4 +24,5 @@ COPY terachem_cloud/ ./terachem_cloud
 EXPOSE 8000
 
 # https://docs.gunicorn.org/en/stable/design.html#how-many-workers
-CMD ["sh", "-c", "gunicorn terachem_cloud.main:app -w 2 -k uvicorn.workers.UvicornWorker --keep-alive 650 -b 0.0.0.0:8000 --access-logfile -"]
+# Timeout to 60s for larger results that require more time to collect from redis
+CMD ["sh", "-c", "gunicorn terachem_cloud.main:app -w 2 -k uvicorn.workers.UvicornWorker --keep-alive 650 --timeout 60 -b 0.0.0.0:8000 --access-logfile -"]

--- a/terachem_cloud/workers/config.py
+++ b/terachem_cloud/workers/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     # backend example: "rediss://:password123@redis.dev.mtzlab.com:6379/0?ssl_cert_reqs=CERT_NONE"; #  pragma: allowlist secret
     celery_backend_connection_string: str = "redis://localhost/0"
     file_server_host: str = "http://localhost"
+    result_expires: int = 259200  # Seconds until results expire in backend
 
     class Config:
         _docker_secrets_dir = "/run/secrets"

--- a/terachem_cloud/workers/tasks.py
+++ b/terachem_cloud/workers/tasks.py
@@ -47,6 +47,7 @@ celery_app.conf.update(
     accept_content=["pickle"],
     result_serializer="pickle",
     task_track_started=True,
+    result_expires=settings.result_expires,
     # Cause workers to only receive and work on one task at a time (no prefetching of messages)
     # https://docs.celeryproject.org/en/stable/userguide/optimizing.html#prefetch-limits
     task_acks_late=True,


### PR DESCRIPTION
…to 60s to accomodate larger results (results >300MB were timing out)

Making these changes to accommodate Ethan's issues with very large (300MB+) results.