### PR TITLE
Fixed /compute/output/ endpoint to correctly return *Output or Progra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Fixed
+
+- Fixed `/compute/output/{task_id}` endpoint to properly return `*Output` or `ProgramFailure` objects for each calculation in a list of inputs.
+
+### Removed
+
+- Removed distinction between `Result` and `ResultGroup` and created a single output object for the `/compute/output/{task_id}` endpoint, `Output`.
+
 ## [0.11.0] - 2023-09-08
 
 ### Added

--- a/chemcloud_server/models.py
+++ b/chemcloud_server/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import AnyHttpUrl, BaseModel, Field
 from qcio import (
@@ -60,23 +60,12 @@ class TaskState(str, Enum):
     IGNORED = "IGNORED"
 
 
-class ResultBaseABC(BaseModel):
-    """Result Base class. Thin wrapper around celery ResultBase"""
+class Output(BaseModel):
+    """Status and result of compute tasks. Wrapper around celery AsyncResult and
+    GroupResult"""
 
     state: TaskState
-    result: Optional[Any] = None
-
-
-class Result(ResultBaseABC):
-    """Status and result of compute tasks. Wrapper around celery AsyncResult"""
-
-    result: Optional[QCIOOutputs] = None
-
-
-class ResultGroup(ResultBaseABC):
-    """Status and result of compute tasks. Wrapper around celery GroupResult"""
-
-    result: Optional[List[QCIOOutputs]] = None
+    result: Optional[Union[QCIOOutputs, List[QCIOOutputs]]] = None
 
 
 class OAuth2Base(BaseModel):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ from celery.states import READY_STATES
 from httpx import HTTPStatusError
 from pydantic import BaseModel
 
-from chemcloud_server.models import Result, ResultGroup, TaskState
+from chemcloud_server.models import Output, TaskState
 
 
 def json_dumps(obj: Union[BaseModel, list[BaseModel]]):
@@ -17,16 +17,14 @@ def json_dumps(obj: Union[BaseModel, list[BaseModel]]):
     return obj.model_dump_json()
 
 
-def _get_result(client, settings, task_id) -> Union[Result, ResultGroup]:
+def _get_result(client, settings, task_id) -> Output:
     # Check Status upon submission
     result = client.get(
         f"{settings.api_v2_str}/compute/output/{task_id}",
     )
     result.raise_for_status()
     as_dict = result.json()
-    if isinstance(as_dict["result"], list):
-        return ResultGroup(**as_dict)
-    return Result(**as_dict)
+    return Output(**as_dict)
 
 
 def _make_job_completion_assertions(task_id, client, settings) -> None:


### PR DESCRIPTION
…mFailure objects for all outputs for a list of inputs. Removed ResultsGroup and created a single returned object--Output.