### PR TITLE
Save the celery results structure to the backend syncronously in the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Fixed
+
+- Random `410` errors caused (presumably) by using a `BackgroundTask` in the `/compute` endpoint to set the `task_id` in celery's backend. I suspect that when users query `/compute/output/{task_id}` right after submitting a big batch it's possible the `BackgroundTask` hasn't set the `task_id` in celery's backend yet and so the spurious `410` is returned due to a race condition.
+
 ## [0.14.4] - 2025-02-08
 
 ### Fixed

--- a/chemcloud_server/routes/compute.py
+++ b/chemcloud_server/routes/compute.py
@@ -27,7 +27,6 @@ router = APIRouter()
     response_description="Task ID for the requested computation.",
 )
 async def compute(
-    background_tasks: BackgroundTasks,
     program: SupportedPrograms,
     inp_obj: ProgramInputsOrList,
     collect_stdout: bool = Query(
@@ -83,7 +82,7 @@ async def compute(
         )
 
     # Save result structure to DB so can be rehydrated using only id
-    background_tasks.add_task(save_dag, future_res)
+    save_dag(future_res)
     return future_res.id
 
 


### PR DESCRIPTION
…/compute endpoint to avoid race conditions when querying /compute/output/{task_id} for the recently submitted task_id.